### PR TITLE
Fix bug at CORS_ORIGIN_WHITELIST in settings.

### DIFF
--- a/backend/calorie/settings.py
+++ b/backend/calorie/settings.py
@@ -141,9 +141,10 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_ORIGIN_WHITELIST = (
-    '*'
-)
+CORS_ORIGIN_WHITELIST = [
+    'http://127.0.0.1',
+    'https://127.0.0.1',
+]
 CORS_ALLOW_METHODS = (
     'DELETE',
     'GET',


### PR DESCRIPTION
The element in CORS_ORIGIN_WHITELIST cannot be '*'.
It should be a scheme (e.g. https://) or netloc (e.g. example.com).